### PR TITLE
Adds getAllProposalsAndVotesByAction to postgres adapters

### DIFF
--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -184,7 +184,7 @@ export const getAllProposalsAndVotesByAction = async (
   space: string,
   actionId: string
 ) => {
-  const queryProposals = `SELECT * FROM messages WHERE space = $1 AND "actionId" = $2 ORDER BY timestamp DESC`;
+  const queryProposals = `SELECT * FROM messages WHERE type = 'proposal' AND space = $1 AND "actionId" = $2 ORDER BY timestamp DESC`;
   const proposalsResult = await db.query(queryProposals, [space, actionId]);
   console.log(proposalsResult.rows.length);
   return await findVotesForProposals(space, proposalsResult.rows);

--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -180,6 +180,16 @@ export const getAllProposalsAndVotes = async (space: string) => {
   return await findVotesForProposals(space, proposalsResult.rows);
 };
 
+export const getAllProposalsAndVotesByAction = async (
+  space: string,
+  actionId: string
+) => {
+  const queryProposals = `SELECT * FROM messages WHERE space = $1 AND "actionId" = $2 ORDER BY timestamp DESC`;
+  const proposalsResult = await db.query(queryProposals, [space, actionId]);
+  console.log(proposalsResult.rows.length);
+  return await findVotesForProposals(space, proposalsResult.rows);
+};
+
 export const getAllDraftsExceptSponsored = async (space: string) => {
   const query = `SELECT * FROM messages WHERE type = 'draft' AND space = $1 AND data ->> 'sponsored' = 'false' ORDER BY timestamp ASC`;
   const result = await db.query(query, [space]);

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,7 +32,8 @@ import {
   getProposalByDraft,
   getAllProposalsAndVotes,
   getAllDraftsExceptSponsored,
-  findVotesForProposals
+  findVotesForProposals,
+  getAllProposalsAndVotesByAction
 } from './helpers/adapters/postgres';
 import pkg from '../package.json';
 /**
@@ -128,11 +129,24 @@ router.get('/:space/proposals', async (req, res) => {
 });
 
 router.get('/:space/proposals/:actionId', async (req, res) => {
+  const includeVotes = req.query.includeVotes;
   const { space, actionId } = req.params;
-  console.log('GET /:space/proposals/:actionId', space, actionId);
-  getMessagesByAction(space, actionId, msgTypes.PROPOSAL)
-    .then(toMessageJson)
-    .then(obj => res.json(obj));
+  console.log(
+    'GET /:space/proposals/:actionId?includeVotes',
+    space,
+    actionId,
+    includeVotes
+  );
+
+  const resultsPromise = includeVotes
+    ? getAllProposalsAndVotesByAction(space, actionId).then(
+        toProposalWithVotesMessageJson
+      )
+    : getMessagesByAction(space, actionId, msgTypes.PROPOSAL).then(
+        toMessageJson
+      );
+
+  resultsPromise.then(obj => res.json(obj));
 });
 
 router.get('/:space/proposal/:id', async (req, res) => {


### PR DESCRIPTION
Fixes #15

Changes proposed in this pull request:
- Adds new `getAllProposalsAndVotesByAction` to postgres adapters
- Adds logic to `GET /:space/proposals/:actionId` to optionally include votes data
