### PR TITLE
Shapes votes as object not array

### DIFF
--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -165,9 +165,7 @@ export const findVotesForProposals = (space, proposals) =>
   Promise.all(
     proposals.map(p =>
       getProposalVotes(space, p.id)
-        .then(votes =>
-          votes && votes.length > 0 ? toVoteMessageJson(votes) : {}
-        )
+        .then(votes => (votes && votes.length > 0 ? toMessageJson(votes) : {}))
         .then(votes => {
           p['votes'] = votes;
           return p;

--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -165,7 +165,9 @@ export const findVotesForProposals = (space, proposals) =>
   Promise.all(
     proposals.map(p =>
       getProposalVotes(space, p.id)
-        .then(votes => votes.map(toVoteMessageJson))
+        .then(votes =>
+          votes && votes.length > 0 ? toVoteMessageJson(votes) : {}
+        )
         .then(votes => {
           p['votes'] = votes;
           return p;

--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -1,5 +1,5 @@
 import db from '../postgres';
-import { toMessageJson, toVoteMessageJson } from '../utils';
+import { toMessageJson, toVoteMessageJson, toVotesMessageJson } from '../utils';
 
 const format = (
   erc712Hash: string,
@@ -165,7 +165,9 @@ export const findVotesForProposals = (space, proposals) =>
   Promise.all(
     proposals.map(p =>
       getProposalVotes(space, p.id)
-        .then(votes => (votes && votes.length > 0 ? toMessageJson(votes) : {}))
+        .then(votes =>
+          votes && votes.length > 0 ? toVotesMessageJson(votes) : []
+        )
         .then(votes => {
           p['votes'] = votes;
           return p;

--- a/server/helpers/utils.ts
+++ b/server/helpers/utils.ts
@@ -133,6 +133,9 @@ export const toVoteMessageJson = (message: any): any => {
   };
 };
 
+export const toVotesMessageJson = (messages: any): any =>
+  messages.map(m => toVoteMessageJson(m));
+
 export const toProposalWithVotesMessageJson = (messages: any): any =>
   Object.fromEntries(
     messages.map(message => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,8 @@ import {
   jsonParse,
   sendError,
   toMessageJson,
-  toProposalWithVotesMessageJson
+  toProposalWithVotesMessageJson,
+  toVotesMessageJson
 } from './helpers/utils';
 import {
   verifySignature,
@@ -176,7 +177,7 @@ router.get('/:space/proposal/:id/votes', async (req, res) => {
   const { space, id } = req.params;
   console.log('GET /:space/proposal/:id/votes', space, id);
   getProposalVotes(space, id)
-    .then(toMessageJson)
+    .then(toVotesMessageJson)
     .then(obj => res.json(obj));
 });
 


### PR DESCRIPTION
Fixes #22 

Changes proposed in this pull request:

- Proposal's `votes: [ ]` are now delivered as an object in the response data to match other implementations.
