### PR TITLE
Detects rowCount instead of rows returned for sponsorDraftIfAny

### DIFF
--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -41,8 +41,7 @@ const insert = async (params: Array<object>) => {
 export const sponsorDraftIfAny = async (space, erc712DraftHash) => {
   const update = `UPDATE messages SET data=data||'{"sponsored": true}' WHERE type = 'draft' AND id = $1 AND space = $2`;
   const result = await db.query(update, [erc712DraftHash, space]);
-  console.log(result.rows.length);
-  return result.rows;
+  return result;
 };
 
 export const storeDraft = async (

--- a/server/index.ts
+++ b/server/index.ts
@@ -411,7 +411,7 @@ router.post('/message', async (req, res) => {
     const sponsorDraftResult = await sponsorDraftIfAny(space, erc712DraftHash);
 
     const erc712DraftHashToSet =
-      sponsorDraftResult.length > 0 ? erc712DraftHash : '';
+      sponsorDraftResult.rowCount > 0 ? erc712DraftHash : '';
 
     await storeProposal(
       space,


### PR DESCRIPTION
Part of #28 

Changes proposed in this pull request:

- Returns entire result from `sponsorDraftIfAny`
- Checks the `result.rowCount` instead of rows returned to see if any Draft was sponsored.

---
cc: @fforbeck I need to merge this so we can keep developing. Let me know know if anything seems wrong and we can fix it today.