### PR TITLE
store and retrieve offchain proofs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
     build: .
     container_name: snapshot-hub
     env_file:
-      - .env.local
+      - ./.env.local
     environment:
       PORT: 8080
       ENV: "local" # local | dev | prod
-      JAWSDB_URL: postgres://admin:admin@snapshot-postgres:5432/snapshot-db
+      JAWSDB_URL: "postgres://admin:admin@snapshot-postgres:5432/snapshot-db"
       USE_IPFS: "false"
     depends_on:
       - snapshot-postgres

--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -215,14 +215,14 @@ export const saveOffchainProof = async (
   merkleRoot: string,
   steps: object
 ) => {
-  const insert = `INSERT INTO merkle_proofs (space, merkle_root, steps) VALUES ($1, $2, $3);`;
-  const result = await db.query(insert, [space, merkleRoot, steps]);
+  const insert = `INSERT INTO offchain_proofs (merkle_root, space, steps) VALUES ($1, $2, $3);`;
+  const result = await db.query(insert, [merkleRoot, space, steps]);
   console.log(result.rows.length);
   return result.rows;
 };
 
 export const getOffchainProof = async (space: string, merkleRoot: string) => {
-  const select = `SELECT * FROM merkle_proofs WHERE space = $1 AND merkle_root = $2;`;
+  const select = `SELECT * FROM offchain_proofs WHERE space = $1 AND merkle_root = $2 LIMIT 1;`;
   const result = await db.query(select, [space, merkleRoot]);
   console.log(result.rows.length);
   return result.rows;

--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -209,3 +209,21 @@ export const getAllDraftsExceptSponsored = async (space: string) => {
   console.log(result.rows.length);
   return result.rows;
 };
+
+export const saveOffchainProof = async (
+  space: string,
+  merkleRoot: string,
+  steps: object
+) => {
+  const insert = `INSERT INTO merkle_proofs (space, merkle_root, steps) VALUES ($1, $2, $3);`;
+  const result = await db.query(insert, [space, merkleRoot, steps]);
+  console.log(result.rows.length);
+  return result.rows;
+};
+
+export const getOffchainProof = async (space: string, merkleRoot: string) => {
+  const select = `SELECT * FROM merkle_proofs WHERE space = $1 AND merkle_root = $2;`;
+  const result = await db.query(select, [space, merkleRoot]);
+  console.log(result.rows.length);
+  return result.rows;
+};

--- a/server/helpers/adapters/postgres.ts
+++ b/server/helpers/adapters/postgres.ts
@@ -213,10 +213,14 @@ export const getAllDraftsExceptSponsored = async (space: string) => {
 export const saveOffchainProof = async (
   space: string,
   merkleRoot: string,
-  steps: object
+  steps: Record<string, any>[]
 ) => {
   const insert = `INSERT INTO offchain_proofs (merkle_root, space, steps) VALUES ($1, $2, $3);`;
-  const result = await db.query(insert, [merkleRoot, space, steps]);
+  const result = await db.query(insert, [
+    merkleRoot,
+    space,
+    JSON.stringify(steps)
+  ]);
   console.log(result.rows.length);
   return result.rows;
 };

--- a/server/helpers/database/schema.sql
+++ b/server/helpers/database/schema.sql
@@ -34,12 +34,8 @@ CREATE INDEX IF NOT EXISTS hubs_address_idx on hubs (address);
 CREATE INDEX IF NOT EXISTS hubs_is_self_idx on hubs (is_self);
 
 CREATE TABLE IF NOT EXISTS offchain_proofs (
-  space VARCHAR(64) NOT NULL,
   merkle_root VARCHAR(64) NOT NULL,
-  steps JSONB NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_DATETIME()
-  PRIMARY KEY (space, merkle_root)
+  space VARCHAR(64) NOT NULL,
+  steps JSONB,
+  PRIMARY KEY (merkle_root)
 );
-
-CREATE INDEX IF NOT EXISTS offchain_proofs_mklr_idx on offchain_proofs (merkle_root);
-CREATE INDEX IF NOT EXISTS offchain_proofs_space_idx on offchain_proofs (space);

--- a/server/helpers/database/schema.sql
+++ b/server/helpers/database/schema.sql
@@ -34,7 +34,7 @@ CREATE INDEX IF NOT EXISTS hubs_address_idx on hubs (address);
 CREATE INDEX IF NOT EXISTS hubs_is_self_idx on hubs (is_self);
 
 CREATE TABLE IF NOT EXISTS offchain_proofs (
-  merkle_root VARCHAR(64) NOT NULL,
+  merkle_root VARCHAR(66) NOT NULL,
   space VARCHAR(64) NOT NULL,
   steps JSONB,
   PRIMARY KEY (merkle_root)

--- a/server/helpers/database/schema.sql
+++ b/server/helpers/database/schema.sql
@@ -32,3 +32,14 @@ CREATE TABLE IF NOT EXISTS hubs (
 
 CREATE INDEX IF NOT EXISTS hubs_address_idx on hubs (address);
 CREATE INDEX IF NOT EXISTS hubs_is_self_idx on hubs (is_self);
+
+CREATE TABLE IF NOT EXISTS offchain_proofs (
+  space VARCHAR(64) NOT NULL,
+  merkle_root VARCHAR(64) NOT NULL,
+  steps JSONB NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_DATETIME()
+  PRIMARY KEY (space, merkle_root)
+);
+
+CREATE INDEX IF NOT EXISTS offchain_proofs_mklr_idx on offchain_proofs (merkle_root);
+CREATE INDEX IF NOT EXISTS offchain_proofs_space_idx on offchain_proofs (space);

--- a/server/index.ts
+++ b/server/index.ts
@@ -226,9 +226,15 @@ router.post('/:space/offchain_proofs', async (req, res) => {
 
   // each step must have the index provided in an incremental order by 1 unit only
   for (let i = 1; i < indexes.length; i++) {
+    // if there's only 1 index, exit before the increment check.
+    if (indexes.length === 1) {
+      return;
+    }
+
     if (indexes[i] - current !== 1) {
       return res.status(400).send({ error: 'invalid indexes' });
     }
+
     current = indexes[i];
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -223,7 +223,7 @@ router.post('/:space/offchain_proofs', async (req, res) => {
   let current = indexes[0];
   if (current !== 0)
     return res.status(400).send({ error: 'invalid initial index' });
-    
+
   // each step must have the index provided in an incremental order by 1 unit only
   for (let i = 1; i < indexes.length; i++) {
     if (indexes[i] - current !== 1) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -208,7 +208,7 @@ router.post('/:space/offchain_proofs', async (req, res) => {
     !chainId ||
     !merkleRoot ||
     !steps ||
-    steps.length < 2 // must have at least 2 steps
+    steps.length < 1 // must have at least 1 steps
   )
     return res.status(400).send({
       error: 'invalid request parameters'

--- a/server/index.ts
+++ b/server/index.ts
@@ -208,7 +208,7 @@ router.post('/:space/offchain_proofs', async (req, res) => {
     !chainId ||
     !merkleRoot ||
     !steps ||
-    steps.length < 1 // must have at least 2 steps
+    steps.length < 2 // must have at least 2 steps
   )
     return res.status(400).send({
       error: 'invalid request parameters'
@@ -243,16 +243,19 @@ router.post('/:space/offchain_proofs', async (req, res) => {
     return res.status(201).send();
   }
 
-  return res.status(403).send({ error: 'invalid merkle root' });
+  return res.status(400).send({ error: 'invalid merkle root' });
 });
 
 router.get('/:space/offchain_proof/:merkleRoot', async (req, res) => {
   const { space, merkleRoot } = req.params;
   return getOffchainProof(space, merkleRoot)
-    .then(p => res.status(200).send(p))
+    .then(p => {
+      if (p && p.length > 0) return res.status(200).send(p);
+      return res.status(404).send([]);
+    })
     .catch(e => {
       console.error(e);
-      return res.status(404).send();
+      return res.status(500).send();
     });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -250,8 +250,8 @@ router.get('/:space/offchain_proof/:merkleRoot', async (req, res) => {
   const { space, merkleRoot } = req.params;
   return getOffchainProof(space, merkleRoot)
     .then(p => {
-      if (p && p.length > 0) return res.status(200).send(p);
-      return res.status(404).send([]);
+      if (p && p.length === 1) return res.status(200).send(p[0]);
+      return res.sendStatus(400);
     })
     .catch(e => {
       console.error(e);

--- a/server/index.ts
+++ b/server/index.ts
@@ -240,7 +240,7 @@ router.post('/:space/offchain_proofs', async (req, res) => {
 
   if (merkleTree.getHexRoot() === merkleRoot) {
     await saveOffchainProof(space, merkleRoot, steps);
-    return res.status(201).send();
+    return res.sendStatus(201);
   }
 
   return res.status(400).send({ error: 'invalid merkle root' });
@@ -251,11 +251,11 @@ router.get('/:space/offchain_proof/:merkleRoot', async (req, res) => {
   return getOffchainProof(space, merkleRoot)
     .then(p => {
       if (p && p.length === 1) return res.status(200).send(p[0]);
-      return res.sendStatus(400);
+      return res.sendStatus(404);
     })
     .catch(e => {
       console.error(e);
-      return res.status(500).send();
+      return res.sendStatus(500);
     });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -214,7 +214,7 @@ router.post('/:space/offchain_proofs', async (req, res) => {
       error: 'invalid request parameters'
     });
 
-  const indexes = steps.map(s => s.index).filter(s => s.index);
+  const indexes = steps.map(s => s.index).filter(s => s >= 0);
   if (indexes.length !== steps.length) {
     return res.status(400).send({ error: 'invalid merkle root' });
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -239,8 +239,14 @@ router.post('/:space/offchain_proofs', async (req, res) => {
   );
 
   if (merkleTree.getHexRoot() === merkleRoot) {
-    await saveOffchainProof(space, merkleRoot, steps);
-    return res.sendStatus(201);
+    try {
+      await saveOffchainProof(space, merkleRoot, steps);
+      return res.sendStatus(201);
+    } catch (error) {
+      return res.status(500).send({
+        error: 'something went wrong while storing the off-chain proof'
+      });
+    }
   }
 
   return res.status(400).send({ error: 'invalid merkle root' });

--- a/server/index.ts
+++ b/server/index.ts
@@ -208,11 +208,29 @@ router.post('/:space/offchain_proofs', async (req, res) => {
     !chainId ||
     !merkleRoot ||
     !steps ||
-    steps.length === 0
+    steps.length < 1 // must have at least 2 steps
   )
     return res.status(400).send({
       error: 'invalid request parameters'
     });
+
+  const indexes = steps.map(s => s.index).filter(s => s.index);
+  if (indexes.length !== steps.length) {
+    return res.status(400).send({ error: 'invalid merkle root' });
+  }
+
+  // the initial index should be always 0
+  let current = indexes[0];
+  if (current !== 0)
+    return res.status(400).send({ error: 'invalid initial index' });
+    
+  // each step must have the index provided in an incremental order by 1 unit only
+  for (let i = 1; i < indexes.length; i++) {
+    if (indexes[i] - current !== 1) {
+      return res.status(400).send({ error: 'invalid indexes' });
+    }
+    current = indexes[i];
+  }
 
   const merkleTree = new MerkleTree(
     steps.map(s =>

--- a/test/api.test.local.http
+++ b/test/api.test.local.http
@@ -1,7 +1,7 @@
 
 # REST Client tests on http://localhost:8080/ server
 # Use docker-composer up --build to launch the test server 
-@baseUrl = http://localhost:8080
+@baseUrl = http://localhost:3000
 ### dev
 #@token = 0x8276d5e4133eba2043a2a9fccc55284c1243f1d4
 ### prod thelao
@@ -59,3 +59,32 @@ GET {{baseUrl}}/api/{{space}}/proposal/QmYWyqesuVTvngwKFhhmAzDrLbJTJYav4d3P21swF
 "QmWWDM8rcrSjXVo4ygFg9jgqvjvq7AdrF66spACeaLgBpH" -> "QmYWyqesuVTvngwKFhhmAzDrLbJTJYav4d3P21swF4HiYd"
 
 GET {{baseUrl}}/api/{{space}}/proposal/QmTdejAMkvSGaYJf345rnN5tG6jHdMyXjrRZY6Bu8UXeVr  HTTP/1.1
+
+### Create proof
+POST {{baseUrl}}/api/{{space}}/offchain_proofs HTTP/1.1
+Content-Type: application/json
+
+{
+  "verifyingContract": "0xEd7B3f2902f2E1B17B027bD0c125B674d293bDA0",
+  "actionId": "test",
+  "chainId": "4",
+  "merkleRoot": "1",
+  "steps": [
+   {
+        "nbYes": 4, 
+        "nbNo": 1,
+        "account": "0xEd7B3f2902f2E1B17B027bD0c125B674d293bDA0",
+        "choice": "2",
+        "proposalHash": "QmeTLYqnrnxR9q4vskShMhkgmUiaX23FGeNLgRcwzCoXiR",
+        "index": 0
+    },
+    {
+        "nbYes": 4, 
+        "nbNo": 1,
+        "account": "0xEd7B3f2902f2E1B17B027bD0c125B674d293bDA0",
+        "choice": "2",
+        "proposalHash": "QmeTLYqnrnxR9q4vskShMhkgmUiaX23FGeNLgRcwzCoXiR",
+        "index": 1
+    }
+  ]
+}

--- a/test/api.test.local.http
+++ b/test/api.test.local.http
@@ -1,7 +1,7 @@
 
 # REST Client tests on http://localhost:8080/ server
 # Use docker-composer up --build to launch the test server 
-@baseUrl = http://localhost:3000
+@baseUrl = http://localhost:8081
 ### dev
 #@token = 0x8276d5e4133eba2043a2a9fccc55284c1243f1d4
 ### prod thelao
@@ -88,3 +88,7 @@ Content-Type: application/json
     }
   ]
 }
+
+### Get proof
+GET {{baseUrl}}/api/{{space}}/offchain_proof/0x8f56682a50becb1df2fb8136954f2062871bc7fc HTTP/1.1
+Content-Type: application/json


### PR DESCRIPTION

**Saves the merkle root and steps of the merkle tree into the Snapshot-Hub DB if the steps and merkle root are valid**
 
`POST /:space/offchain_proofs` - d 

- Request
```json
  "verifyingContract": "...",
  "actionId": "...",
  "chainId": "...",
  "merkleRoot": "...",
  "steps": [
   {
    "nbYes": "...", 
    "nbNo": "...",
    "account": "...",
    "choice": "...",
    "proposalHash": "...",
    "index": "..."
    }
  ]
```

**Retrieves the steps of the merkle tree based on the space and merkle root**
`GET /:space/offchain_proof/:merkleRoot`

* Response
```json
  "merkleRoot": "...",
  "steps": [
   {
    "nbYes": "...", 
    "nbNo": "...",
    "account": "...",
    "choice": "...",
    "proposalHash": "...",
    "index": "..."
    }
  ]
```
