### PR TITLE
Allow vote end constraint to be ignored

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,31 @@
+# Node version matching the version declared in the package.json
+FROM node:14.0-slim
+
+# Update O.S.
+RUN apt-get update && apt-get upgrade -y
+
+# Install required O.S. packages
+RUN apt-get install -y git python make g++
+
+# Create the application workdir
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+
+# Set current user
+USER node
+
+# Copy app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+
+# Install app dependencies
+RUN npm ci --only=production
+
+# Bundle app source
+COPY --chown=node:node . .
+
+# Set the container port
+EXPOSE 8080
+
+# Start the aplication
+CMD ["npm", "run", "express"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       ENV: "local" # local | dev | prod
       JAWSDB_URL: "postgres://admin:admin@snapshot-postgres:5432/snapshot-db"
       USE_IPFS: "false"
+      IGNORE_VOTE_END_CONSTRAINT: "true"
     depends_on:
       - snapshot-postgres
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ services:
 
   # Snapshot hub
   snapshot-hub:
-    build: .
+    build:
+      # Use the development `Dockerfile.dev`
+      context: .
+      dockerfile: Dockerfile.dev
     container_name: snapshot-hub
     env_file:
       - ./.env.local
@@ -16,6 +19,8 @@ services:
       - snapshot-postgres
     ports:
       - 8081:8080
+    volumes:
+      - .:/home/node/app
 
   # Snapshot Postgres instance
   snapshot-postgres:


### PR DESCRIPTION
Fixes #44 

**Changes proposed in this pull request:**

- Allow for a proposal's vote submit to ignore the proposal's vote `payload.end` timestamp
- Use `Dockerfile.dev` for development. 
NOTE: Could get out of sync with `Dockerfile` - not sure how to override only a portion of the main file? cc: @fforbeck 
- Hot reloading for development
